### PR TITLE
Long address bug fix

### DIFF
--- a/ZBank.Application/Wallets/Commands/CreateWallet/CreateWalletCommandValidator.cs
+++ b/ZBank.Application/Wallets/Commands/CreateWallet/CreateWalletCommandValidator.cs
@@ -8,7 +8,7 @@ public class CreateWalletCommandValidator : AbstractValidator<CreateWalletComman
     {
         RuleFor(x => x.Address)
             .NotEmpty().WithMessage("Address is required")
-            .Length(20, 200).WithMessage("Address must be between 20 and 200 characters long");
+            .Length(20, 100).WithMessage("Address must be between 20 and 100 characters long");
         
         RuleFor(x => x.Type)
             .NotEmpty().WithMessage("Type is required");

--- a/ZBank.Infrastructure/Migrations/ZBankDbContextModelSnapshot.cs
+++ b/ZBank.Infrastructure/Migrations/ZBankDbContextModelSnapshot.cs
@@ -262,8 +262,8 @@ namespace ZBank.Infrastructure.Migrations
 
                     b.Property<string>("Address")
                         .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
 
                     b.Property<DateTime>("CreatedDateTime")
                         .HasColumnType("timestamp with time zone");

--- a/ZBank.Infrastructure/Persistance/Configurations/WalletConfigurations.cs
+++ b/ZBank.Infrastructure/Persistance/Configurations/WalletConfigurations.cs
@@ -32,7 +32,7 @@ public class WalletConfigurations : IEntityTypeConfiguration<Wallet>
         //Name
         builder.Property(x => x.Address)
             .IsRequired()
-            .HasMaxLength(50);
+            .HasMaxLength(100);
     }
 
     private void ConfigureBalancesTable(EntityTypeBuilder<Wallet> builder)


### PR DESCRIPTION
Fixed a bug where wallet address longer than 50 characters caused BadRequest status code without any meaningful validation message. Limited wallet address length to 100, ensured that whenever the length limit is exceeded a meaningful validation message is shown in resoponse 